### PR TITLE
weather_lamp_esp: add missing semicolon

### DIFF
--- a/ESP8266 Code/weather_Lamp_esp.ino
+++ b/ESP8266 Code/weather_Lamp_esp.ino
@@ -50,7 +50,7 @@ int login_counter = 20;                               // Number of login tries
 const char* ssidAP = "esp8266";
 const char* passwordAP = "****";
 
-String cookieID = "*****"
+String cookieID = "*****";
 
 String username;
 String pass;


### PR DESCRIPTION
A semicolon was missing after the cookieID definition.

Fixes https://github.com/vagtsal/Weather-Lamp/issues/2

CC: @benevolution 